### PR TITLE
add new api : get_all_available_account and get_random_available_account

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,45 @@ Action: `random_sharepage_password` \
 |------------|----------|-----|
 | `password` | `String` | 新密码 |
 
+Action: `get_all_available_account` \
+说明： 获取json格式的全部可用账户信息 \
+输入参数：
+| 参数       | 值/类型                        | 说明    |
+|----------|-----------------------------|-------|
+| `action` | `get_all_available_account` | 操作    |
+
+返回参数：
+
+| 参数         | 值/类型     | 说明  |
+|------------|----------|-----|
+| `data` | `ArrayList` | 一个包含可用账户信息的数组 
+示例：
+```
+{
+    "username": "test@outlook.com",
+    "password": "test12344",
+    "last_check": "2023-02-24 20:56:04"
+} 
+```
+
+Action: `get_random_available_account` \
+说明： 从可用账户中随机获取一个账户  \
+输入参数：
+
+| 参数       | 值/类型                        | 说明    |
+|----------|-----------------------------|-------|
+| `action` | `get_random_available_account` | 操作    |
+
+返回参数：
+
+| 参数         | 值/类型     | 说明  |
+|------------|----------|-----|
+| `apple_id` | `String` | 账户用户名
+| `apple_pwd` | `String` | 账户密码 
+| `last_check` | `Date` | 最后一次更新的时间
+
+
+
 
 
 ……其余等待添加

--- a/api/index.php
+++ b/api/index.php
@@ -205,6 +205,40 @@ switch ($_GET["action"]) {
         }
         break;
     }
+    // 随机获取一个有效账户
+    case "get_random_available_account":
+    {
+        $result = $conn->prepare("SELECT username,password,last_check FROM account WHERE message='正常';");
+        $result->execute();
+        $available_account = $result->fetchall();
+        $rand_account_index = array_rand($available_account);
+        $appid_id = $available_account[$rand_account_index]['username'];
+        $appid_pwd = $available_account[$rand_account_index]['password']; 
+        $last_check = $available_account[$rand_account_index]['last_check'];
+        $data = array(
+            'status' => 'success',
+            'message' => '获取成功',
+            'apple_id' => $appid_id,
+            'apple_pwd' => $appid_pwd,
+            'last_check' => $last_check
+        );
+        break;   
+    }
+    //获取全部可用账户 
+    case "get_all_available_account":
+    {
+        $result = $conn->prepare("SELECT username,password,last_check FROM account WHERE message='正常';");
+        $result->execute();
+        $available_account = $result->fetchall(PDO::FETCH_CLASS);
+    
+        $data = array(
+            'status' => 'success',
+            'message' => '获取成功',
+            'data' => $available_account,
+        );
+        break;   
+    }
+    
     default:
     {
         $data = array(


### PR DESCRIPTION
新增了两个api，用于将账户信息嵌入其他应用中：
- get_random_available_account  随机获取一个有效账户
- get_all_available_account   获取全部可用的账户

V2board 嵌入知识库实例：
文件：/app/Http/Controllers/User/KnowledgeController.php  中 fetch() 方法内添加
```
if(strpos($knowledge['body'], '{{apple_id}}') !== false){
                $appleId_url = "https://unlock.403w.club/api/?key=114514&action=get_random_available_account";
                $content = json_decode(file_get_contents($appleId_url));
                $knowledge['body'] = str_replace('{{apple_id}}', $content->apple_id, $knowledge['body']);
                $knowledge['body'] = str_replace('{{apple_pwd}}', $content->apple_pwd, $knowledge['body']);
                $knowledge['body'] = str_replace('{{apple_uptime}}', $content->last_check, $knowledge['body']);
 }
```

在知识库中 就可以使用 {apple_id}，{apple_pwd} 等来展示可用账户信息